### PR TITLE
feat: Add detailed error messages for connection issues

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,6 +20,7 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
@@ -48,7 +49,11 @@ android {
             signingConfig = signingConfigs.getByName("release")
           }
     }
+    dependencies {
+       coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    }
 }
+
 
 flutter {
     source = "../.."

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,10 +77,10 @@ class _ZakStreamerState extends State<ZakStreamer> {
               ValueListenableBuilder<String>(
                 valueListenable: getIt<PageManager>().errorNotifier,
                 builder: (_, error, __) {
-                  if (error.isEmpty) return const SizedBox.shrink();
+                  if (error.isEmpty) return const SizedBox(height: 67);
                   return Padding(
-                    padding: const EdgeInsets.only(top: 24.0),
-                    child: Text(error, style: const TextStyle(color: Colors.red, fontSize: 16)),
+                    padding: const EdgeInsets.only(top: 48.0),
+                    child: Text(error, style: const TextStyle(fontSize: 14)),
                   );
                 },
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ Future<void> main() async {
     await Notifications.init();
     final session = await AudioSession.instance;
     await session.configure(AudioSessionConfiguration.music());
-    runApp(ZakStreamer());
+    runApp(const ZakStreamer());
   } catch (e) {
     log.severe('Streamer failed', e);
   }
@@ -53,6 +53,7 @@ class _ZakStreamerState extends State<ZakStreamer> {
   @override
   void dispose() {
     _notificationSubscription?.cancel();
+    getIt<PageManager>().dispose();
     super.dispose();
   }
 
@@ -70,9 +71,19 @@ class _ZakStreamerState extends State<ZakStreamer> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text('Wciśnij Kropkę, aby włączyć alternatywę.'),
-              SizedBox(height: 75),
-              PlayButton(),
+              const Text('Wciśnij Kropkę, aby włączyć alternatywę.'),
+              const SizedBox(height: 75),
+              const PlayButton(),
+              ValueListenableBuilder<String>(
+                valueListenable: getIt<PageManager>().errorNotifier,
+                builder: (_, error, __) {
+                  if (error.isEmpty) return const SizedBox.shrink();
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 24.0),
+                    child: Text(error, style: const TextStyle(color: Colors.red, fontSize: 16)),
+                  );
+                },
+              ),
             ],
           ),
         ),
@@ -91,13 +102,12 @@ class PlayButton extends StatelessWidget {
       builder: (_, value, __) {
         switch (value) {
           case ButtonState.loading:
-            return SizedBox(
+            return const SizedBox(
               width: 300,
               height: 300,
-              child: const CircularProgressIndicator(
+              child: CircularProgressIndicator(
                 strokeWidth: 15,
                 strokeCap: StrokeCap.round,
-                constraints: BoxConstraints(maxWidth: 200, maxHeight: 200),
                 color: Colors.tealAccent,
               ),
             );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:logging/logging.dart';
@@ -34,10 +35,25 @@ class ZakStreamer extends StatefulWidget {
 }
 
 class _ZakStreamerState extends State<ZakStreamer> {
+  StreamSubscription? _notificationSubscription;
+
   @override
   void initState() {
     super.initState();
     getIt<PageManager>().init();
+    Notifications.requestPermission();
+
+    _notificationSubscription = Notifications.onNotificationTapped.stream.listen((payload) {
+      if (payload == 'reconnect') {
+        getIt<PageManager>().play();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _notificationSubscription?.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:audio_session/audio_session.dart';
-import "package:logging/logging.dart";
+import 'package:logging/logging.dart';
 import 'package:simple_animations/animation_builder/custom_animation_builder.dart';
 import 'page_manager.dart';
 import 'service_locator.dart';
 import 'package:flutter/services.dart';
+import 'notifications.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final log = Logger('Main');
   Logger.root.level = Level.ALL; // defaults to Level.INFO
   Logger.root.onRecord.listen((record) {
@@ -15,6 +17,7 @@ Future<void> main() async {
 
   try {
     await setupServiceLocator();
+    await Notifications.init();
     final session = await AudioSession.instance;
     await session.configure(AudioSessionConfiguration.music());
     runApp(ZakStreamer());

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -7,10 +7,15 @@ class Notifications {
 
   static Future<void> init() async {
     const AndroidInitializationSettings initializationSettingsAndroid =
-        AndroidInitializationSettings('app_icon');
+        AndroidInitializationSettings('@mipmap/launcher_icon');
     const InitializationSettings initializationSettings =
         InitializationSettings(android: initializationSettingsAndroid);
     await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
+
+    await _flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestNotificationsPermission();
   }
 
   static Future<void> showNotification({

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -1,0 +1,37 @@
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class Notifications {
+  static final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  static Future<void> init() async {
+    const AndroidInitializationSettings initializationSettingsAndroid =
+        AndroidInitializationSettings('app_icon');
+    const InitializationSettings initializationSettings =
+        InitializationSettings(android: initializationSettingsAndroid);
+    await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
+  }
+
+  static Future<void> showNotification({
+    required String title,
+    required String body,
+  }) async {
+    const AndroidNotificationDetails androidPlatformChannelSpecifics =
+        AndroidNotificationDetails(
+      'zak_streamer_channel',
+      'Zak Streamer',
+      importance: Importance.max,
+      priority: Priority.high,
+      showWhen: false,
+    );
+    const NotificationDetails platformChannelSpecifics =
+        NotificationDetails(android: androidPlatformChannelSpecifics);
+    await _flutterLocalNotificationsPlugin.show(
+      0,
+      title,
+      body,
+      platformChannelSpecifics,
+    );
+  }
+}

--- a/lib/notifications.dart
+++ b/lib/notifications.dart
@@ -1,17 +1,28 @@
+import 'dart:async';
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 class Notifications {
-  static final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
+  static final _flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();
+
+  static final onNotificationTapped = StreamController<String?>.broadcast();
 
   static Future<void> init() async {
     const AndroidInitializationSettings initializationSettingsAndroid =
         AndroidInitializationSettings('@mipmap/launcher_icon');
-    const InitializationSettings initializationSettings =
-        InitializationSettings(android: initializationSettingsAndroid);
-    await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
+    const InitializationSettings initializationSettings = InitializationSettings(
+      android: initializationSettingsAndroid,
+    );
+    await _flutterLocalNotificationsPlugin.initialize(
+      initializationSettings,
+      onDidReceiveNotificationResponse: (response) {
+        onNotificationTapped.add(response.payload);
+      },
+    );
+  }
 
+  static Future<void> requestPermission() async {
     await _flutterLocalNotificationsPlugin
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>()
@@ -21,6 +32,7 @@ class Notifications {
   static Future<void> showNotification({
     required String title,
     required String body,
+    String? payload,
   }) async {
     const AndroidNotificationDetails androidPlatformChannelSpecifics =
         AndroidNotificationDetails(
@@ -37,6 +49,7 @@ class Notifications {
       title,
       body,
       platformChannelSpecifics,
+      payload: payload,
     );
   }
 }

--- a/lib/page_manager.dart
+++ b/lib/page_manager.dart
@@ -25,6 +25,7 @@ class PageManager {
 
   void _listenToPlaybackState() {
     _audioHandler.playbackState.listen((playbackState) {
+      if (errorNotifier.value.isNotEmpty) return;
       final isPlaying = playbackState.playing;
       final processingState = playbackState.processingState;
       if (processingState == AudioProcessingState.loading ||
@@ -42,6 +43,7 @@ class PageManager {
     _customEventSubscription = _audioHandler.customEvent.listen((event) {
       if (event is Map && event['type'] == 'error') {
         errorNotifier.value = event['message'] as String;
+        playButtonNotifier.value = ButtonState.paused;
       } else if (event is Map && event['type'] == 'clear_error') {
         errorNotifier.value = '';
       }

--- a/lib/streamer.dart
+++ b/lib/streamer.dart
@@ -65,6 +65,7 @@ class Streamer extends BaseAudioHandler {
               Notifications.showNotification(
                 title: 'Utrata połączenia',
                 body: 'Połączenie ze strumieniem zostało przerwane.',
+                payload: 'reconnect',
               );
             }
           });
@@ -98,6 +99,7 @@ class Streamer extends BaseAudioHandler {
         Notifications.showNotification(
           title: 'Brak połączenia',
           body: 'Nie udało się połączyć z serwerem. Spróbuj ponownie.',
+          payload: 'reconnect',
         );
       }
     });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -121,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   fake_async:
     dependency: transitive
     description:
@@ -162,10 +178,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_cache_manager
-      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.3.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -182,6 +198,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.2.4"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -200,14 +240,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.0"
-  http:
-    dependency: transitive
+  html:
+    dependency: "direct main"
     description:
-      name: http
-      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "0.15.6"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.6"
   http_parser:
     dependency: transitive
     description:
@@ -436,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.28.0"
+    version: "0.27.7"
   safe_local_storage:
     dependency: transitive
     description:
@@ -557,6 +605,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   typed_data:
     dependency: transitive
     description:
@@ -639,4 +695,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: "3.38.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.9.2
-  flutter: 3.38.4
+  flutter: 3.38.5
 dependencies:
   flutter:
     sdk: flutter
@@ -17,12 +17,14 @@ dependencies:
   logging: ^1.3.0
   audio_service: ^0.18.18
   get_it: ^9.2.0
+  http: ^0.13.3
+  html: ^0.15.0
+  flutter_local_notifications: ^17.1.2
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   flutter_launcher_icons: "^0.14.4"
-
 flutter:
   uses-material-design: true
 


### PR DESCRIPTION
resolves #3
Implements a robust error handling mechanism to provide users with specific feedback on playback failures.

What's been done:
Error Notifications:
◦The app now sends push notifications when a connection fails or is lost during playback.
◦Clicking on an error notification takes the user back to the app and automatically attempts to reconnect.

Detailed UI Messages:
◦Precise error messages now appear under the main "Play" button.
◦ The app logic actively checks internet access to correctly distinguish between a phone connection failure and a problem with the radio server.

UI Consistency:
◦When an error occurs, the playback or loading animation stops and the button returns to its idle state to avoid user confusion.
◦ Fixed race conditions that caused error messages to be incorrectly overwritten or disappear prematurely.


◦ When a generic "source error" occurs, the app now actively checks for a valid internet connection by attempting to reach an external server.
◦ This allows differentiating between a local network problem ("No internet connection. Check your network settings.") and a server-side issue ("The stream is currently unavailable. Please try again later.").
◦ Fixes a race condition where a "Connection to the stream was lost" message was being incorrectly overridden by a subsequent, more generic error.