### PR TITLE
feat: Add "Now Playing" widget to home screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:audio_session/audio_session.dart';
-import "package:logging/logging.dart";
+import 'package:logging/logging.dart';
 import 'package:simple_animations/animation_builder/custom_animation_builder.dart';
 import 'page_manager.dart';
+import 'schedule_page.dart';
 import 'service_locator.dart';
 import 'package:flutter/services.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final log = Logger('Main');
   Logger.root.level = Level.ALL; // defaults to Level.INFO
   Logger.root.onRecord.listen((record) {
@@ -17,7 +19,7 @@ Future<void> main() async {
     await setupServiceLocator();
     final session = await AudioSession.instance;
     await session.configure(AudioSessionConfiguration.music());
-    runApp(ZakStreamer());
+    runApp(const ZakStreamer());
   } catch (e) {
     log.severe('Streamer failed', e);
   }
@@ -46,16 +48,35 @@ class _ZakStreamerState extends State<ZakStreamer> {
     return MaterialApp(
       title: 'Żak Streamer',
       theme: ThemeData.dark(),
-      home: Scaffold(
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text('Wciśnij Kropkę, aby włączyć alternatywę.'),
-              SizedBox(height: 75),
-              PlayButton(),
-            ],
-          ),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Wciśnij Kropkę, aby włączyć alternatywę.'),
+            const SizedBox(height: 75),
+            const PlayButton(),
+            const SizedBox(height: 48),
+            TextButton(
+              child: const Text('POKAŻ RAMÓWKĘ'),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const SchedulePage()),
+                );
+              },
+            ),
+          ],
         ),
       ),
     );
@@ -72,13 +93,12 @@ class PlayButton extends StatelessWidget {
       builder: (_, value, __) {
         switch (value) {
           case ButtonState.loading:
-            return SizedBox(
+            return const SizedBox(
               width: 300,
               height: 300,
-              child: const CircularProgressIndicator(
+              child: CircularProgressIndicator(
                 strokeWidth: 15,
                 strokeCap: StrokeCap.round,
-                constraints: BoxConstraints(maxWidth: 200, maxHeight: 200),
                 color: Colors.tealAccent,
               ),
             );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:logging/logging.dart';
 import 'package:simple_animations/animation_builder/custom_animation_builder.dart';
+import 'package:zakstreamer/widgets/now_playing_widget.dart';
 import 'page_manager.dart';
 import 'schedule_page.dart';
 import 'service_locator.dart';
@@ -40,6 +41,12 @@ class _ZakStreamerState extends State<ZakStreamer> {
   }
 
   @override
+  void dispose() {
+    getIt<PageManager>().dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
@@ -63,10 +70,11 @@ class HomePage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            const NowPlayingWidget(),
             const Text('Wciśnij Kropkę, aby włączyć alternatywę.'),
-            const SizedBox(height: 75),
+            const SizedBox(height: 24),
             const PlayButton(),
-            const SizedBox(height: 48),
+            const SizedBox(height: 24),
             TextButton(
               child: const Text('POKAŻ RAMÓWKĘ'),
               onPressed: () {

--- a/lib/page_manager.dart
+++ b/lib/page_manager.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:audio_service/audio_service.dart';
+import 'package:zakstreamer/schedule_service.dart';
+
 import 'service_locator.dart';
 
 enum ButtonState { playing, paused, loading }
@@ -10,12 +14,59 @@ class PlayButtonNotifier extends ValueNotifier<ButtonState> {
 }
 
 class PageManager {
+  // Notifiers
   final playButtonNotifier = PlayButtonNotifier();
+  final nowPlayingNotifier = ValueNotifier<ScheduleEntry?>(null);
+
+  // Dependencies
+  final _audioHandler = getIt<AudioHandler>();
+  final _scheduleService = getIt<ScheduleService>();
+
+  // State
+  Timer? _nowPlayingTimer;
+  Map<String, List<ScheduleEntry>>? _fullSchedule;
+
   void init() {
     _listenToPlaybackState();
+    _initializeNowPlayingFeature();
   }
 
-  final _audioHandler = getIt<AudioHandler>();
+  Future<void> _initializeNowPlayingFeature() async {
+    try {
+      // Fetch the schedule once.
+      _fullSchedule = await _scheduleService.fetchSchedule();
+      // Perform the first check immediately.
+      _updateNowPlaying();
+      // Start a timer to check every minute.
+      _nowPlayingTimer = Timer.periodic(const Duration(minutes: 1), (_) {
+        _updateNowPlaying();
+      });
+    } catch (e) {
+      print("Failed to initialize Now Playing feature: $e");
+    }
+  }
+
+  void _updateNowPlaying() {
+    if (_fullSchedule == null) return;
+
+    final todayIndex = (DateTime.now().weekday - 1).clamp(0, 6);
+    final todayKey = _fullSchedule!.keys.elementAt(todayIndex);
+    final entriesToday = _fullSchedule![todayKey] ?? [];
+
+    ScheduleEntry? liveEntry;
+    for (final entry in entriesToday) {
+      if (entry.isLive) {
+        liveEntry = entry;
+        break; // Find the first one and stop
+      }
+    }
+
+    // Only notify listeners if the show has actually changed.
+    if (nowPlayingNotifier.value?.title != liveEntry?.title) {
+      nowPlayingNotifier.value = liveEntry;
+    }
+  }
+
   void _listenToPlaybackState() {
     _audioHandler.playbackState.listen((playbackState) {
       final isPlaying = playbackState.playing;
@@ -35,4 +86,8 @@ class PageManager {
 
   void play() => _audioHandler.play();
   void pause() => _audioHandler.pause();
+
+  void dispose() {
+    _nowPlayingTimer?.cancel();
+  }
 }

--- a/lib/page_manager.dart
+++ b/lib/page_manager.dart
@@ -11,12 +11,12 @@ class PlayButtonNotifier extends ValueNotifier<ButtonState> {
 
 class PageManager {
   final playButtonNotifier = PlayButtonNotifier();
-  void init() async {
-    await _listenToPlaybackState();
+  void init() {
+    _listenToPlaybackState();
   }
 
   final _audioHandler = getIt<AudioHandler>();
-  Future<void> _listenToPlaybackState() async {
+  void _listenToPlaybackState() {
     _audioHandler.playbackState.listen((playbackState) {
       final isPlaying = playbackState.playing;
       final processingState = playbackState.processingState;

--- a/lib/schedule_page.dart
+++ b/lib/schedule_page.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'service_locator.dart';
+import 'schedule_service.dart';
+
+class SchedulePage extends StatefulWidget {
+  const SchedulePage({super.key});
+
+  @override
+  State<SchedulePage> createState() => _SchedulePageState();
+}
+
+class _SchedulePageState extends State<SchedulePage> {
+  Future<Map<String, List<ScheduleEntry>>>? _scheduleFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleFuture = getIt<ScheduleService>().fetchSchedule();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Ramówka'),
+      ),
+      body: FutureBuilder<Map<String, List<ScheduleEntry>>>(
+        future: _scheduleFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text('Nie udało się załadować ramówki.\nBłąd: ${snapshot.error}', textAlign: TextAlign.center),
+            ));
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('Brak danych ramówki.'));
+          }
+
+          final schedule = snapshot.data!;
+          final days = schedule.keys.toList();
+
+          return DefaultTabController(
+            length: days.length,
+            child: Column(
+              children: [
+                TabBar(
+                  isScrollable: true,
+                  labelStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  unselectedLabelStyle: const TextStyle(fontWeight: FontWeight.normal),
+                  tabs: days.map((day) => Tab(text: day)).toList(),
+                ),
+                Expanded(
+                  child: TabBarView(
+                    children: days.map((day) {
+                      final entries = schedule[day]!;
+                      return ListView.separated(
+                        padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 8.0),
+                        itemCount: entries.length,
+                        separatorBuilder: (context, index) => const Divider(height: 24),
+                        itemBuilder: (context, index) {
+                          final entry = entries[index];
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '${entry.time} - ${entry.title}',
+                                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                              ),
+                              if (entry.hosts.isNotEmpty)
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 4.0),
+                                  child: Text(
+                                    'Prowadzący: ${entry.hosts}',
+                                    style: TextStyle(fontSize: 14, color: Colors.white70),
+                                  ),
+                                ),
+                            ],
+                          );
+                        },
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/schedule_page.dart
+++ b/lib/schedule_page.dart
@@ -11,31 +11,63 @@ class SchedulePage extends StatefulWidget {
 }
 
 class _SchedulePageState extends State<SchedulePage> with TickerProviderStateMixin {
-  Future<Map<String, List<ScheduleEntry>>>? _scheduleFuture;
+  // State variables to hold the data, loading, and error states
+  Map<String, List<ScheduleEntry>>? _schedule;
+  Object? _error;
+  bool _isLoading = true;
+
   TabController? _tabController;
   final List<ItemScrollController> _scrollControllers = List.generate(7, (_) => ItemScrollController());
+
+  // State variables to hold the position of the live show
+  int _liveDayIndex = -1;
+  int _liveShowIndex = -1;
 
   @override
   void initState() {
     super.initState();
-    _scheduleFuture = getIt<ScheduleService>().fetchSchedule();
+    _fetchDataAndSetup();
   }
 
-  void _scrollToCurrentShow(int dayIndex, Map<String, List<ScheduleEntry>> schedule) {
-    final todayIndex = DateTime.now().weekday - 1;
-    if (dayIndex != todayIndex) return;
+  Future<void> _fetchDataAndSetup() async {
+    try {
+      final scheduleData = await getIt<ScheduleService>().fetchSchedule();
+      if (!mounted) return;
 
-    final currentDayController = _scrollControllers[dayIndex];
-    final todayEntries = schedule.values.elementAt(dayIndex);
-    final currentShowIndex = todayEntries.indexWhere((entry) => entry.isLive);
+      // Find the live show ONCE and store its position
+      final today = (DateTime.now().weekday - 1).clamp(0, 6);
+      final entriesToday = scheduleData.values.elementAt(today);
+      final liveIndex = entriesToday.indexWhere((e) => e.isLive);
 
-    if (currentShowIndex != -1 && currentDayController.isAttached) {
-      currentDayController.scrollTo(
-        index: currentShowIndex,
-        duration: const Duration(milliseconds: 800),
-        curve: Curves.easeInOutCubic,
-        alignment: 0.3,
-      );
+      setState(() {
+        _schedule = scheduleData;
+        _isLoading = false;
+        _liveDayIndex = today;
+        _liveShowIndex = liveIndex;
+
+        final days = scheduleData.keys.toList();
+        _tabController = TabController(length: days.length, vsync: this, initialIndex: today);
+      });
+
+      // Schedule the scroll to after the first frame has been built
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_liveShowIndex != -1) {
+          _scrollControllers[_liveDayIndex].scrollTo(
+            index: _liveShowIndex,
+            duration: const Duration(milliseconds: 800),
+            curve: Curves.easeInOutCubic,
+            alignment: 0.3, // Scroll to 30% from the top
+          );
+        }
+      });
+
+    } catch (e, stackTrace) {
+      print('Error fetching schedule: $e\n$stackTrace');
+      if (!mounted) return;
+      setState(() {
+        _error = e;
+        _isLoading = false;
+      });
     }
   }
 
@@ -51,105 +83,98 @@ class _SchedulePageState extends State<SchedulePage> with TickerProviderStateMix
       appBar: AppBar(
         title: const Text('Ramówka'),
       ),
-      body: FutureBuilder<Map<String, List<ScheduleEntry>>>(
-        future: _scheduleFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasError) {
-            return Center(child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Text('Nie udało się załadować ramówki.\nBłąd: ${snapshot.error}', textAlign: TextAlign.center),
-            ));
-          }
-          if (!snapshot.hasData || snapshot.data!.isEmpty) {
-            return const Center(child: Text('Brak danych ramówki.'));
-          }
+      body: _buildBody(),
+    );
+  }
 
-          final schedule = snapshot.data!;
-          final days = schedule.keys.toList();
-          final todayWeekday = DateTime.now().weekday;
-          final initialDayIndex = (todayWeekday - 1).clamp(0, days.length - 1);
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Text('Nie udało się załadować ramówki.\nBłąd: $_error', textAlign: TextAlign.center),
+      ));
+    }
+    if (_schedule == null || _schedule!.isEmpty) {
+      return const Center(child: Text('Brak danych ramówki.'));
+    }
 
-          _tabController ??= TabController(length: days.length, vsync: this, initialIndex: initialDayIndex);
+    final schedule = _schedule!;
+    final days = schedule.keys.toList();
 
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            _scrollToCurrentShow(initialDayIndex, schedule);
-          });
+    return Column(
+      children: [
+        TabBar(
+          controller: _tabController,
+          isScrollable: true,
+          labelStyle: const TextStyle(fontWeight: FontWeight.bold),
+          unselectedLabelStyle: const TextStyle(fontWeight: FontWeight.normal),
+          tabs: days.map((day) => Tab(text: day)).toList(),
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: schedule.entries.map((dayEntry) {
+              final dayIndex = days.indexOf(dayEntry.key);
+              final entries = dayEntry.value;
 
-          return Column(
-            children: [
-              TabBar(
-                controller: _tabController,
-                isScrollable: true,
-                labelStyle: const TextStyle(fontWeight: FontWeight.bold),
-                unselectedLabelStyle: const TextStyle(fontWeight: FontWeight.normal),
-                tabs: days.map((day) => Tab(text: day)).toList(),
-              ),
-              Expanded(
-                child: TabBarView(
-                  controller: _tabController,
-                  children: schedule.entries.map((dayEntry) {
-                    final dayIndex = days.indexOf(dayEntry.key);
-                    final entries = dayEntry.value;
-                    return ScrollablePositionedList.separated(
-                      itemScrollController: _scrollControllers[dayIndex],
-                      padding: const EdgeInsets.symmetric(vertical: 16.0),
-                      itemCount: entries.length,
-                      separatorBuilder: (context, index) => const Divider(indent: 16, endIndent: 16, height: 24),
-                      itemBuilder: (context, index) {
-                        final entry = entries[index];
-                        // A show is live ONLY if the time is correct AND it's the current day of the week.
-                        final bool isLive = entry.isLive && dayIndex == initialDayIndex;
-                        return Container(
-                          color: isLive ? Colors.teal.withOpacity(0.25) : Colors.transparent,
-                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          child: Row(
+              return ScrollablePositionedList.separated(
+                itemScrollController: _scrollControllers[dayIndex],
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                itemCount: entries.length,
+                separatorBuilder: (context, index) => const Divider(indent: 16, endIndent: 16, height: 24),
+                itemBuilder: (context, index) {
+                  final entry = entries[index];
+                  // The check is now simple and stable, based on pre-calculated state
+                  final bool isLiveNow = (dayIndex == _liveDayIndex && index == _liveShowIndex);
+
+                  return Container(
+                    color: isLiveNow ? Colors.teal.withOpacity(0.25) : Colors.transparent,
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Row(
+                      children: [
+                        SizedBox(
+                          width: 36,
+                          child: isLiveNow 
+                            ? const Icon(Icons.volume_up_outlined, color: Colors.tealAccent)
+                            : null,
+                        ),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              SizedBox(
-                                width: 36,
-                                child: isLive 
-                                  ? const Icon(Icons.volume_up_outlined, color: Colors.tealAccent)
-                                  : null,
-                              ),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      '${entry.time} - ${entry.title}',
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: isLive ? FontWeight.bold : FontWeight.normal,
-                                      ),
-                                    ),
-                                    if (entry.hosts.isNotEmpty)
-                                      Padding(
-                                        padding: const EdgeInsets.only(top: 4.0),
-                                        child: Text(
-                                          'Prowadzący: ${entry.hosts}',
-                                          style: TextStyle(
-                                            fontSize: 14,
-                                            color: isLive ? Colors.white : Colors.white70,
-                                          ),
-                                        ),
-                                      ),
-                                  ],
+                              Text(
+                                '${entry.time} - ${entry.title}',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: isLiveNow ? FontWeight.bold : FontWeight.normal,
                                 ),
                               ),
+                              if (entry.hosts.isNotEmpty)
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 4.0),
+                                  child: Text(
+                                    'Prowadzący: ${entry.hosts}',
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      color: isLiveNow ? Colors.white : Colors.white70,
+                                    ),
+                                  ),
+                                ),
                             ],
                           ),
-                        );
-                      },
-                    );
-                  }).toList(),
-                ),
-              ),
-            ],
-          );
-        },
-      ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              );
+            }).toList(),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/schedule_service.dart
+++ b/lib/schedule_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
 
@@ -35,7 +36,8 @@ class ScheduleService {
       final response = await http.get(Uri.parse(_baseUrl + path), headers: headers);
 
       if (response.statusCode == 200) {
-        final document = parser.parse(response.body);
+        // Decode the response body using UTF-8 to handle Polish characters
+        final document = parser.parse(utf8.decode(response.bodyBytes));
         final entries = <ScheduleEntry>[];
         
         final entryElements = document.querySelectorAll('ul#ramowka > li.row');
@@ -46,8 +48,8 @@ class ScheduleService {
           String title = '';
           final aTag = entryElement.querySelector('h3.tytul > a');
           if (aTag != null) {
-            final aClone = aTag.clone(true); // Deep clone to avoid modifying the original document
-            aClone.querySelector('span.show-for-small')?.remove(); // Remove the duplicated time span
+            final aClone = aTag.clone(true);
+            aClone.querySelector('span.show-for-small')?.remove();
             title = aClone.text.trim();
           }
 

--- a/lib/schedule_service.dart
+++ b/lib/schedule_service.dart
@@ -4,42 +4,92 @@ import 'package:html/parser.dart' as parser;
 class ScheduleEntry {
   final String time;
   final String title;
+  final String hosts;
 
-  ScheduleEntry({required this.time, required this.title});
+  ScheduleEntry({required this.time, required this.title, required this.hosts});
 
   @override
-  String toString() => '[$time] $title';
+  String toString() => '[$time] $title (Hosts: $hosts)';
 }
 
 class ScheduleService {
-  final _url = Uri.parse('https://www.zak.lodz.pl/ramowka');
+  final _baseUrl = 'https://www.zak.lodz.pl';
+  final _dayPaths = {
+    'Poniedziałek': '/ramowka/plan/1/poniedzialek/',
+    'Wtorek': '/ramowka/plan/2/wtorek/',
+    'Środa': '/ramowka/plan/3/sroda/',
+    'Czwartek': '/ramowka/plan/4/czwartek/',
+    'Piątek': '/ramowka/plan/5/piatek/',
+    'Sobota': '/ramowka/plan/6/sobota/',
+    'Niedziela': '/ramowka/plan/7/niedziela/',
+  };
 
   Future<Map<String, List<ScheduleEntry>>> fetchSchedule() async {
-    final response = await http.get(_url);
-    if (response.statusCode != 200) {
-      throw Exception('Failed to load schedule. Status code: ${response.statusCode}');
-    }
-
-    final document = parser.parse(response.body);
     final scheduleMap = <String, List<ScheduleEntry>>{};
+    final headers = {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36',
+    };
 
-    final dayElements = document.querySelectorAll('.ramowka-dzien');
+    for (var dayName in _dayPaths.keys) {
+      final path = _dayPaths[dayName]!;
+      final response = await http.get(Uri.parse(_baseUrl + path), headers: headers);
 
-    for (var dayElement in dayElements) {
-      final dayTitle = dayElement.querySelector('.dzien-title')?.text.trim();
-      if (dayTitle != null && dayTitle.isNotEmpty) {
+      if (response.statusCode == 200) {
+        final document = parser.parse(response.body);
         final entries = <ScheduleEntry>[];
-        final entryElements = dayElement.querySelectorAll('.ramowka-wpis');
+        
+        final entryElements = document.querySelectorAll('ul#ramowka > li.row');
+
         for (var entryElement in entryElements) {
-          final time = entryElement.querySelector('.ramowka-godzina')?.text.trim() ?? '';
-          final title = entryElement.querySelector('.ramowka-tytul')?.text.trim() ?? '';
+          final time = entryElement.querySelector('div.godziny')?.text.trim() ?? '';
+          
+          String title = '';
+          final aTag = entryElement.querySelector('h3.tytul > a');
+          if (aTag != null) {
+            final aClone = aTag.clone(true); // Deep clone to avoid modifying the original document
+            aClone.querySelector('span.show-for-small')?.remove(); // Remove the duplicated time span
+            title = aClone.text.trim();
+          }
+
+          String hosts = '';
+          final opisDiv = entryElement.querySelector('div.opis');
+          if (opisDiv != null) {
+            final descPrefixSpans = opisDiv.querySelectorAll('span.desc-prefix');
+            for (var span in descPrefixSpans) {
+              if (span.text.trim().startsWith('prowadz')) {
+                final hostSpan = span.nextElementSibling;
+                if (hostSpan != null && hostSpan.localName == 'span') {
+                  hosts = hostSpan.text.trim();
+                  break;
+                }
+              }
+            }
+          }
+          
           if (time.isNotEmpty && title.isNotEmpty) {
-            entries.add(ScheduleEntry(time: time, title: title));
+            entries.add(ScheduleEntry(time: time, title: title, hosts: hosts));
           }
         }
-        scheduleMap[dayTitle] = entries;
+        if (entries.isNotEmpty) {
+          scheduleMap[dayName] = entries;
+        }
+      } else {
+        print('Failed to load schedule for $dayName. Status code: ${response.statusCode}');
       }
     }
-    return scheduleMap;
+
+    if (scheduleMap.isEmpty) {
+      throw Exception('Failed to fetch or parse schedule from any of the daily pages.');
+    }
+
+    // Sort the final map to ensure the days are in the correct order
+    final sortedScheduleMap = <String, List<ScheduleEntry>>{};
+    for (var day in _dayPaths.keys) {
+      if (scheduleMap.containsKey(day)) {
+        sortedScheduleMap[day] = scheduleMap[day]!;
+      }
+    }
+
+    return sortedScheduleMap;
   }
 }

--- a/lib/schedule_service.dart
+++ b/lib/schedule_service.dart
@@ -9,14 +9,6 @@ class ScheduleEntry {
 
   ScheduleEntry({required this.time, required this.title, required this.hosts});
 
-  factory ScheduleEntry.fromJson(Map<String, dynamic> json) {
-    return ScheduleEntry(
-      time: json['godzina'] as String,
-      title: json['tytul'] as String,
-      hosts: '', // Will be populated by HTML parsing
-    );
-  }
-
   bool get isLive {
     try {
       final now = DateTime.now();
@@ -33,22 +25,16 @@ class ScheduleEntry {
       final endMinute = int.parse(endTimeParts[1]);
 
       final startTime = DateTime(now.year, now.month, now.day, startHour, startMinute);
+      // The end time could be on the next day
       var endTime = DateTime(now.year, now.month, now.day, endHour, endMinute);
-
-      // Handle shows that cross midnight (e.g., 23:00 - 01:00)
+      
       if (endTime.isBefore(startTime)) {
-        // If current time is after midnight but before end time, we are in the next day part of the show.
-        if (now.isBefore(endTime)) {
-          // We are in the same logical day as endTime, do nothing.
-        } else {
-          // The show started yesterday.
-          endTime = endTime.add(const Duration(days: 1));
-        }
-      } 
+        endTime = endTime.add(const Duration(days: 1));
+      }
 
       return now.isAfter(startTime) && now.isBefore(endTime);
     } catch (e) {
-      return false; // If parsing fails for any reason, it's not live.
+      return false;
     }
   }
 
@@ -126,6 +112,7 @@ class ScheduleService {
       throw Exception('Failed to fetch or parse schedule from any of the daily pages.');
     }
 
+    // Sort the final map to ensure the days are in the correct order
     final sortedScheduleMap = <String, List<ScheduleEntry>>{};
     for (var day in _dayPaths.keys) {
       if (scheduleMap.containsKey(day)) {

--- a/lib/schedule_service.dart
+++ b/lib/schedule_service.dart
@@ -1,0 +1,45 @@
+import 'package:http/http.dart' as http;
+import 'package:html/parser.dart' as parser;
+
+class ScheduleEntry {
+  final String time;
+  final String title;
+
+  ScheduleEntry({required this.time, required this.title});
+
+  @override
+  String toString() => '[$time] $title';
+}
+
+class ScheduleService {
+  final _url = Uri.parse('https://www.zak.lodz.pl/ramowka');
+
+  Future<Map<String, List<ScheduleEntry>>> fetchSchedule() async {
+    final response = await http.get(_url);
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load schedule. Status code: ${response.statusCode}');
+    }
+
+    final document = parser.parse(response.body);
+    final scheduleMap = <String, List<ScheduleEntry>>{};
+
+    final dayElements = document.querySelectorAll('.ramowka-dzien');
+
+    for (var dayElement in dayElements) {
+      final dayTitle = dayElement.querySelector('.dzien-title')?.text.trim();
+      if (dayTitle != null && dayTitle.isNotEmpty) {
+        final entries = <ScheduleEntry>[];
+        final entryElements = dayElement.querySelectorAll('.ramowka-wpis');
+        for (var entryElement in entryElements) {
+          final time = entryElement.querySelector('.ramowka-godzina')?.text.trim() ?? '';
+          final title = entryElement.querySelector('.ramowka-tytul')?.text.trim() ?? '';
+          if (time.isNotEmpty && title.isNotEmpty) {
+            entries.add(ScheduleEntry(time: time, title: title));
+          }
+        }
+        scheduleMap[dayTitle] = entries;
+      }
+    }
+    return scheduleMap;
+  }
+}

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -2,10 +2,12 @@ import 'package:audio_service/audio_service.dart';
 import 'page_manager.dart';
 import 'streamer.dart';
 import 'package:get_it/get_it.dart';
+import 'schedule_service.dart';
 
 GetIt getIt = GetIt.instance;
 
 Future<void> setupServiceLocator() async {
   getIt.registerSingleton<AudioHandler>(await initAudioService());
   getIt.registerLazySingleton<PageManager>(() => PageManager());
+  getIt.registerLazySingleton<ScheduleService>(() => ScheduleService());
 }

--- a/lib/widgets/now_playing_widget.dart
+++ b/lib/widgets/now_playing_widget.dart
@@ -9,50 +9,60 @@ class NowPlayingWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final pageManager = getIt<PageManager>();
-    
+
     return ValueListenableBuilder<ScheduleEntry?>(
       valueListenable: pageManager.nowPlayingNotifier,
       builder: (_, nowPlaying, __) {
-        // If nothing is playing or data is not yet loaded, return an empty container.
-        if (nowPlaying == null) {
-          return const SizedBox.shrink();
-        }
-
-        // If a show is playing, display its details.
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'TERAZ GRAMY',
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: Colors.white70,
-                  letterSpacing: 1.5,
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                nowPlaying.title,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              if (nowPlaying.hosts.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.only(top: 4.0),
-                  child: Text(
-                    'Prowadzący: ${nowPlaying.hosts}',
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Colors.white70,
-                    ),
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 750),
+          transitionBuilder: (Widget child, Animation<double> animation) {
+            return FadeTransition(
+              opacity: animation,
+              child: child,
+            );
+          },
+          child: nowPlaying == null
+              // When no show is live, display an empty box with a specific key.
+              // The key is crucial for AnimatedSwitcher to detect a change.
+              ? const SizedBox(key: ValueKey('empty'))
+              // When a show is live, display its details.
+              : Padding(
+                  // The key changes when the show title changes, triggering the animation.
+                  key: ValueKey(nowPlaying.title),
+                  padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'TERAZ GRAMY',
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                              color: Colors.white70,
+                              letterSpacing: 1.5,
+                            ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        nowPlaying.title,
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
+                      if (nowPlaying.hosts.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4.0),
+                          child: Text(
+                            'Prowadzący: ${nowPlaying.hosts}',
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                  color: Colors.white70,
+                                ),
+                          ),
+                        ),
+                      const SizedBox(height: 48),
+                    ],
                   ),
                 ),
-              const SizedBox(height: 48), // Add space between this widget and the player button
-            ],
-          ),
         );
       },
     );

--- a/lib/widgets/now_playing_widget.dart
+++ b/lib/widgets/now_playing_widget.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:zakstreamer/page_manager.dart';
+import 'package:zakstreamer/schedule_service.dart';
+import 'package:zakstreamer/service_locator.dart';
+
+class NowPlayingWidget extends StatelessWidget {
+  const NowPlayingWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final pageManager = getIt<PageManager>();
+    
+    return ValueListenableBuilder<ScheduleEntry?>(
+      valueListenable: pageManager.nowPlayingNotifier,
+      builder: (_, nowPlaying, __) {
+        // If nothing is playing or data is not yet loaded, return an empty container.
+        if (nowPlaying == null) {
+          return const SizedBox.shrink();
+        }
+
+        // If a show is playing, display its details.
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'TERAZ GRAMY',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Colors.white70,
+                  letterSpacing: 1.5,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                nowPlaying.title,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              if (nowPlaying.hosts.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4.0),
+                  child: Text(
+                    'Prowadzący: ${nowPlaying.hosts}',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Colors.white70,
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 48), // Add space between this widget and the player button
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -464,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  scrollable_positioned_list:
+    dependency: "direct main"
+    description:
+      name: scrollable_positioned_list
+      sha256: "1b54d5f1329a1e263269abc9e2543d90806131aa14fe7c6062a8054d57249287"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.8"
   simple_animations:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -162,10 +170,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_cache_manager
-      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.3.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -200,14 +208,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.0"
-  http:
-    dependency: transitive
+  html:
+    dependency: "direct main"
     description:
-      name: http
-      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "0.15.6"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.6"
   http_parser:
     dependency: transitive
     description:
@@ -436,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.28.0"
+    version: "0.27.7"
   safe_local_storage:
     dependency: transitive
     description:
@@ -639,4 +655,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: "3.38.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   get_it: ^9.2.0
   http: ^0.13.3
   html: ^0.15.0
+  scrollable_positioned_list: ^0.3.8
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: ^3.9.2
-  flutter: 3.38.4
+  flutter: 3.38.5
 dependencies:
   flutter:
     sdk: flutter
@@ -17,6 +17,8 @@ dependencies:
   logging: ^1.3.0
   audio_service: ^0.18.18
   get_it: ^9.2.0
+  http: ^0.13.3
+  html: ^0.15.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This Pull Request introduces a "Now Playing" feature to the main screen, providing users with real-time information about the currently airing show.

•New Feature: "Now Playing" Widget
◦Adds a new section above the player controls that displays the current show's title and host(s).
◦This information automatically refreshes every minute to stay up-to-date.
◦The widget is hidden if no show is currently scheduled to be playing.

•Smooth UI/UX
◦When the show changes, the text updates with a smooth fade-in/fade-out animation for a more polished and professional feel.

•Efficient Backend Logic
◦The PageManager now fetches the entire schedule once and caches it.
◦A periodic Timer checks against the cached schedule every minute to determine the live show, minimizing network usage.
◦A new ValueNotifier efficiently communicates the current show details to the UI.