### PR TITLE
feat: Add share functionality for current show

### DIFF
--- a/lib/widgets/now_playing_widget.dart
+++ b/lib/widgets/now_playing_widget.dart
@@ -50,11 +50,25 @@ class NowPlayingActiveWidget extends NowPlayingWidget {
             child: Column(
               key: ValueKey(nowPlaying?.title),
               children: [
-                Text(
-                  'TERAZ GRAMY',
-                  style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
+                Row(
+                  children: [
+                    const SizedBox(width: 48.0), // Spacer to balance the button on the right
+                    Expanded(
+                      child: Text(
+                        'TERAZ GRAMY',
+                        textAlign: TextAlign.center, // Center the text
+                        style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                          color: Theme.of(context).colorScheme.primary,
+                              letterSpacing: 1.5,
+                            ),
+                      ),
+                    ),
+                    PopupMenuButton<String>(
+                      icon: const Icon(Icons.more_vert, color: Colors.tealAccent),
+                      onSelected: (value) {},
+                      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[],
+                    ),
+                  ],
                 ),
                 const SizedBox(height: 8),
                 Text(

--- a/lib/widgets/now_playing_widget.dart
+++ b/lib/widgets/now_playing_widget.dart
@@ -74,6 +74,8 @@ class NowPlayingActiveWidget extends NowPlayingWidget {
                 Text(
                   nowPlaying!.title,
                   textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
                 if (nowPlaying.hosts.isNotEmpty)
@@ -82,6 +84,8 @@ class NowPlayingActiveWidget extends NowPlayingWidget {
                     child: Text(
                       'Prowadzący: ${nowPlaying.hosts}',
                       textAlign: TextAlign.center,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.labelLarge,
                     ),
                   ),

--- a/lib/widgets/now_playing_widget.dart
+++ b/lib/widgets/now_playing_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:zakstreamer/now_playing.dart';
 import 'package:zakstreamer/schedule_service.dart';
 import 'package:zakstreamer/service_locator.dart';
@@ -65,8 +66,22 @@ class NowPlayingActiveWidget extends NowPlayingWidget {
                     ),
                     PopupMenuButton<String>(
                       icon: const Icon(Icons.more_vert, color: Colors.tealAccent),
-                      onSelected: (value) {},
-                      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[],
+                      onSelected: (value) {
+                        if (value == 'share') {
+                          var shareText =
+                              'Słucham właśnie "${nowPlaying?.title}" w Studenckim Radiu Żak PŁ! Dołącz do mnie na 88,8 MHz!';
+                          Share.share(shareText);
+                        }
+                      },
+                      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+                        const PopupMenuItem<String>(
+                          value: 'share',
+                          child: ListTile(
+                            leading: Icon(Icons.share),
+                            title: Text('Udostępnij audycję'),
+                          ),
+                        ),
+                      ],
                     ),
                   ],
                 ),

--- a/lib/widgets/now_playing_widget.dart
+++ b/lib/widgets/now_playing_widget.dart
@@ -53,35 +53,43 @@ class NowPlayingActiveWidget extends NowPlayingWidget {
               children: [
                 Row(
                   children: [
-                    const SizedBox(width: 48.0), // Spacer to balance the button on the right
+                    const SizedBox(
+                      width: 48.0,
+                    ), // Spacer to balance the button on the right
                     Expanded(
                       child: Text(
                         'TERAZ GRAMY',
                         textAlign: TextAlign.center, // Center the text
-                        style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.primary,
+                        style: Theme.of(context).textTheme.titleMedium!
+                            .copyWith(
+                              color: Theme.of(context).colorScheme.primary,
                               letterSpacing: 1.5,
                             ),
                       ),
                     ),
                     PopupMenuButton<String>(
-                      icon: const Icon(Icons.more_vert, color: Colors.tealAccent),
+                      icon: Icon(
+                        Icons.more_vert,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
                       onSelected: (value) {
                         if (value == 'share') {
-                          var shareText =
+                          final shareText =
                               'Słucham właśnie "${nowPlaying?.title}" w Studenckim Radiu Żak PŁ! Dołącz do mnie na 88,8 MHz!';
+                          // ignore: deprecated_member_use
                           Share.share(shareText);
                         }
                       },
-                      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-                        const PopupMenuItem<String>(
-                          value: 'share',
-                          child: ListTile(
-                            leading: Icon(Icons.share),
-                            title: Text('Udostępnij audycję'),
-                          ),
-                        ),
-                      ],
+                      itemBuilder: (BuildContext context) =>
+                          <PopupMenuEntry<String>>[
+                            const PopupMenuItem<String>(
+                              value: 'share',
+                              child: ListTile(
+                                leading: Icon(Icons.share),
+                                title: Text('Udostępnij audycję'),
+                              ),
+                            ),
+                          ],
                     ),
                   ],
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_local_notifications: ^19.5.0
   scrollable_positioned_list: ^0.3.8
   google_fonts: ^7.0.0
+  share_plus: ^12.0.1
 
 dev_dependencies:
   flutter_test:
@@ -33,3 +34,21 @@ flutter:
 
   assets:
     - assets/
+
+flutter_launcher_icons:
+  android: "launcher_icon"
+  ios: true
+  image_path: "assets/zak-kropka-niebieska-biale.png"
+  min_sdk_android: 16 # android min sdk min:16, default 21
+  web:
+    generate: true
+    image_path: "assets/zak-kropka-niebieska-biale.png"
+    background_color: "#hexcode"
+    theme_color: "#hexcode"
+  windows:
+    generate: true
+    image_path: "assets/zak-kropka-niebieska-biale.png"
+    icon_size: 48 # min:48, max:256, default: 48
+  macos:
+    generate: true
+    image_path: "assets/zak-kropka-niebieska-biale.png"


### PR DESCRIPTION
•New Feature: Share Button
◦Adds a "Share" icon to the "Now Playing" widget on the main screen.
◦Tapping the icon opens the native system share sheet.

•Share Content
◦The shared message includes the title of the currently playing show and the station's frequency.
◦Example: "Słucham właśnie "Audycja X" w Studenckim Radiu Żak PŁ! Dołącz do mnie na 88,8 MHz!"

•Dependencies
◦Adds the share_plus package to handle the sharing logic.