### PR TITLE
fix: Implement retry mechanism for now playing fetching

### DIFF
--- a/lib/widgets/now_playing_widget.dart
+++ b/lib/widgets/now_playing_widget.dart
@@ -19,7 +19,7 @@ class NowPlayingWidget extends StatelessWidget {
             return FadeTransition(opacity: animation, child: child);
           },
           child: SizedBox(
-            height: 120,
+            height: 130,
             child: Center(
               child: nowPlaying == null
                   // When no show is live, display an empty box with a specific key.


### PR DESCRIPTION
Problem:
Currently, if the application is launched without an active internet connection, it fails to fetch the schedule data. This causes the "Now Playing" widget to remain in a permanent loading state. Even if the network connection is restored, the app does not attempt to refetch the data, forcing the user to restart the application.
Solution:
This PR introduces a robust retry mechanism within the NowPlaying service to handle initial network failures gracefully.
•
If the initial schedule fetch fails (e.g., due to a SocketException when offline), the service now initiates a retry timer.
•
It will automatically attempt to fetch the schedule every 5 seconds.
•
Once the schedule is successfully fetched, the retry timer is cancelled, and the service resumes its normal behavior (updating the "Now Playing" information periodically).
This ensures that the app can recover from a lack of internet connection at startup without any user intervention, significantly improving the user experience and application resilience.