### PR TITLE
Feat/statistics v2.0

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:logging/logging.dart';
+import 'package:zakstreamer/statistics_page.dart';
 import 'package:zakstreamer/statistics_service.dart';
 import 'package:zakstreamer/widgets/play_button.dart';
 import 'package:zakstreamer/widgets/now_playing_widget.dart';
@@ -130,6 +131,20 @@ class HomePage extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => const SchedulePage(),
+                    ),
+                  );
+                },
+              ),
+              TextButton(
+                child: const Text(
+                  'STATYSTYKI',
+                  style: TextStyle(color: Colors.tealAccent),
+                ),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const StatisticsPage(),
                     ),
                   );
                 },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:logging/logging.dart';
+import 'package:zakstreamer/statistics_service.dart';
 import 'package:zakstreamer/widgets/play_button.dart';
 import 'package:zakstreamer/widgets/now_playing_widget.dart';
 import 'page_manager.dart';
@@ -71,6 +72,7 @@ class _ZakStreamerState extends State<ZakStreamer> {
   void initState() {
     super.initState();
     getIt<PageManager>().init();
+    getIt<StatisticsService>().init();
     Notifications.requestPermission();
 
     _notificationSubscription = Notifications.onNotificationTapped.stream

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -138,7 +138,7 @@ class HomePage extends StatelessWidget {
               TextButton(
                 child: const Text(
                   'STATYSTYKI',
-                  style: TextStyle(color: Colors.tealAccent),
+                  style: TextStyle(color: Colors.white),
                 ),
                 onPressed: () {
                   Navigator.push(

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -17,6 +17,6 @@ Future<void> setupServiceLocator() async {
 
   // Statistics
   getIt.registerLazySingleton<StatisticsRepository>(() => StatisticsRepository());
-  getIt.registerLazySingleton<StatisticsService>(
-      () => StatisticsService(getIt<StatisticsRepository>()));
+  getIt.registerLazySingleton<StatisticsService>(() => StatisticsService(
+      getIt<StatisticsRepository>(), getIt<AudioHandler>()));
 }

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -1,5 +1,7 @@
 import 'package:audio_service/audio_service.dart';
 import 'page_manager.dart';
+import 'statistics_repository.dart';
+import 'statistics_service.dart';
 import 'streamer.dart';
 import 'package:get_it/get_it.dart';
 import 'schedule_service.dart';
@@ -12,4 +14,9 @@ Future<void> setupServiceLocator() async {
   getIt.registerLazySingleton<PageManager>(() => PageManager());
   getIt.registerLazySingleton<NowPlaying>(() => NowPlaying());
   getIt.registerLazySingleton<ScheduleService>(() => ScheduleService());
+
+  // Statistics
+  getIt.registerLazySingleton<StatisticsRepository>(() => StatisticsRepository());
+  getIt.registerLazySingleton<StatisticsService>(
+      () => StatisticsService(getIt<StatisticsRepository>()));
 }

--- a/lib/statistics_page.dart
+++ b/lib/statistics_page.dart
@@ -13,6 +13,8 @@ class _StatisticsPageState extends State<StatisticsPage> {
   final StatisticsService _statisticsService = getIt<StatisticsService>();
   DateTime? _installDate;
   int _totalListeningTime = 0;
+  int _longestSession = 0;
+  int _shortestSession = 0;
 
   @override
   void initState() {
@@ -23,13 +25,18 @@ class _StatisticsPageState extends State<StatisticsPage> {
   Future<void> _loadStatistics() async {
     final installDate = await _statisticsService.getInstallDate();
     final totalListeningTime = await _statisticsService.getTotalListeningTime();
+    final longestSession = await _statisticsService.getLongestSession();
+    final shortestSession = await _statisticsService.getShortestSession();
     setState(() {
       _installDate = installDate;
       _totalListeningTime = totalListeningTime;
+      _longestSession = longestSession;
+      _shortestSession = shortestSession;
     });
   }
 
-  String _formatTotalTime(int totalSeconds) {
+  String _formatDuration(int totalSeconds) {
+    if (totalSeconds == 0) return 'Brak danych';
     final duration = Duration(seconds: totalSeconds);
     final hours = duration.inHours;
     final minutes = duration.inMinutes.remainder(60);
@@ -60,10 +67,19 @@ class _StatisticsPageState extends State<StatisticsPage> {
         children: [
           _StatisticRow(
             label: 'Słuchasz Żaka już łącznie:',
-            value: _formatTotalTime(_totalListeningTime),
+            value: _formatDuration(_totalListeningTime),
           ),
           const Divider(),
-          // TODO: Implement other statistics
+          _StatisticRow(
+            label: 'Najdłuższa sesja:',
+            value: _formatDuration(_longestSession),
+          ),
+          const Divider(),
+          _StatisticRow(
+            label: 'Najkrótsza sesja:',
+            value: _formatDuration(_shortestSession),
+          ),
+          const Divider(),
           _StatisticRow(
             label: 'Data instalacji ŻAK Playera:',
             value: _formatInstallDate(_installDate),

--- a/lib/statistics_page.dart
+++ b/lib/statistics_page.dart
@@ -1,7 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:zakstreamer/service_locator.dart';
+import 'package:zakstreamer/statistics_service.dart';
 
-class StatisticsPage extends StatelessWidget {
+class StatisticsPage extends StatefulWidget {
   const StatisticsPage({super.key});
+
+  @override
+  State<StatisticsPage> createState() => _StatisticsPageState();
+}
+
+class _StatisticsPageState extends State<StatisticsPage> {
+  final StatisticsService _statisticsService = getIt<StatisticsService>();
+  DateTime? _installDate;
+  int _totalListeningTime = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadStatistics();
+  }
+
+  Future<void> _loadStatistics() async {
+    final installDate = await _statisticsService.getInstallDate();
+    final totalListeningTime = await _statisticsService.getTotalListeningTime();
+    setState(() {
+      _installDate = installDate;
+      _totalListeningTime = totalListeningTime;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -9,8 +35,16 @@ class StatisticsPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Statystyki'),
       ),
-      body: const Center(
-        child: Text('Wkrótce tutaj pojawią się statystyki.'),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Słuchasz Żaka już łącznie: $_totalListeningTime sekund'),
+            const SizedBox(height: 16),
+            Text('Data instalacji ŻAK Playera: ${_installDate?.toLocal()?.toString() ?? 'Brak danych'}'),
+          ],
+        ),
       ),
     );
   }

--- a/lib/statistics_page.dart
+++ b/lib/statistics_page.dart
@@ -57,15 +57,27 @@ class _StatisticsPageState extends State<StatisticsPage> {
     });
   }
 
+  String _pluralize(int count, String one, String few, String many) {
+    if (count == 1) return one;
+    if (count % 100 >= 11 && count % 100 <= 19) return many;
+    final lastDigit = count % 10;
+    if (lastDigit >= 2 && lastDigit <= 4) return few;
+    return many;
+  }
+
   String _formatDuration(int totalSeconds) {
     final duration = Duration(seconds: totalSeconds);
     final hours = duration.inHours;
     final minutes = duration.inMinutes.remainder(60);
 
+    final hoursString = '$hours ${_pluralize(hours, 'godzina', 'godziny', 'godzin')}';
+    final minutesString = '$minutes ${_pluralize(minutes, 'minuta', 'minuty', 'minut')}';
+
     if (hours > 0) {
-      return '$hours godzin $minutes minut';
+      if (minutes == 0) return hoursString;
+      return '$hoursString $minutesString';
     } else {
-      return '$minutes minut';
+      return minutesString;
     }
   }
 

--- a/lib/statistics_page.dart
+++ b/lib/statistics_page.dart
@@ -15,6 +15,7 @@ class _StatisticsPageState extends State<StatisticsPage> {
   int _totalListeningTime = 0;
   int _longestSession = 0;
   int _shortestSession = 0;
+  String _mostListenedDay = 'Brak danych';
 
   @override
   void initState() {
@@ -27,11 +28,13 @@ class _StatisticsPageState extends State<StatisticsPage> {
     final totalListeningTime = await _statisticsService.getTotalListeningTime();
     final longestSession = await _statisticsService.getLongestSession();
     final shortestSession = await _statisticsService.getShortestSession();
+    final mostListenedDay = await _statisticsService.getMostListenedDay();
     setState(() {
       _installDate = installDate;
       _totalListeningTime = totalListeningTime;
       _longestSession = longestSession;
       _shortestSession = shortestSession;
+      _mostListenedDay = mostListenedDay;
     });
   }
 
@@ -78,6 +81,11 @@ class _StatisticsPageState extends State<StatisticsPage> {
           _StatisticRow(
             label: 'Najkrótsza sesja:',
             value: _formatDuration(_shortestSession),
+          ),
+          const Divider(),
+          _StatisticRow(
+            label: 'Dzień, kiedy najczęściej słuchasz Żaka to:',
+            value: _mostListenedDay,
           ),
           const Divider(),
           _StatisticRow(

--- a/lib/statistics_page.dart
+++ b/lib/statistics_page.dart
@@ -55,16 +55,43 @@ class _StatisticsPageState extends State<StatisticsPage> {
       appBar: AppBar(
         title: const Text('Statystyki'),
       ),
-      body: Padding(
+      body: ListView(
         padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Słuchasz Żaka już łącznie: ${_formatTotalTime(_totalListeningTime)}'),
-            const SizedBox(height: 16),
-            Text('Data instalacji ŻAK Playera: ${_formatInstallDate(_installDate)}'),
-          ],
-        ),
+        children: [
+          _StatisticRow(
+            label: 'Słuchasz Żaka już łącznie:',
+            value: _formatTotalTime(_totalListeningTime),
+          ),
+          const Divider(),
+          // TODO: Implement other statistics
+          _StatisticRow(
+            label: 'Data instalacji ŻAK Playera:',
+            value: _formatInstallDate(_installDate),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatisticRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _StatisticRow({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: textTheme.bodyMedium),
+          const SizedBox(height: 4),
+          Text(value, style: textTheme.headlineSmall),
+        ],
       ),
     );
   }

--- a/lib/statistics_page.dart
+++ b/lib/statistics_page.dart
@@ -29,6 +29,26 @@ class _StatisticsPageState extends State<StatisticsPage> {
     });
   }
 
+  String _formatTotalTime(int totalSeconds) {
+    final duration = Duration(seconds: totalSeconds);
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60);
+
+    if (hours > 0) {
+      return '$hours godzin $minutes minut';
+    } else {
+      return '$minutes minut';
+    }
+  }
+
+  String _formatInstallDate(DateTime? date) {
+    if (date == null) return 'Brak danych';
+    final day = date.day.toString().padLeft(2, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final year = date.year;
+    return '$day.$month.$year';
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -40,9 +60,9 @@ class _StatisticsPageState extends State<StatisticsPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Słuchasz Żaka już łącznie: $_totalListeningTime sekund'),
+            Text('Słuchasz Żaka już łącznie: ${_formatTotalTime(_totalListeningTime)}'),
             const SizedBox(height: 16),
-            Text('Data instalacji ŻAK Playera: ${_installDate?.toLocal()?.toString() ?? 'Brak danych'}'),
+            Text('Data instalacji ŻAK Playera: ${_formatInstallDate(_installDate)}'),
           ],
         ),
       ),

--- a/lib/statistics_page.dart
+++ b/lib/statistics_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class StatisticsPage extends StatelessWidget {
+  const StatisticsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Statystyki'),
+      ),
+      body: const Center(
+        child: Text('Wkrótce tutaj pojawią się statystyki.'),
+      ),
+    );
+  }
+}

--- a/lib/statistics_repository.dart
+++ b/lib/statistics_repository.dart
@@ -3,6 +3,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 class StatisticsRepository {
   static const _installDateKey = 'install_date';
   static const _totalListeningTimeKey = 'total_listening_time';
+  static const _longestSessionKey = 'longest_session';
+  static const _shortestSessionKey = 'shortest_session';
 
   Future<void> saveInstallDate() async {
     final prefs = await SharedPreferences.getInstance();
@@ -25,5 +27,25 @@ class StatisticsRepository {
   Future<int> getTotalListeningTime() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(_totalListeningTimeKey) ?? 0;
+  }
+
+  Future<void> saveLongestSession(int seconds) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_longestSessionKey, seconds);
+  }
+
+  Future<int> getLongestSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_longestSessionKey) ?? 0;
+  }
+
+  Future<void> saveShortestSession(int seconds) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_shortestSessionKey, seconds);
+  }
+
+  Future<int> getShortestSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_shortestSessionKey) ?? 0;
   }
 }

--- a/lib/statistics_repository.dart
+++ b/lib/statistics_repository.dart
@@ -2,6 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class StatisticsRepository {
   static const _installDateKey = 'install_date';
+  static const _totalListeningTimeKey = 'total_listening_time';
 
   Future<void> saveInstallDate() async {
     final prefs = await SharedPreferences.getInstance();
@@ -14,5 +15,15 @@ class StatisticsRepository {
     final prefs = await SharedPreferences.getInstance();
     final dateString = prefs.getString(_installDateKey);
     return dateString != null ? DateTime.parse(dateString) : null;
+  }
+
+  Future<void> saveTotalListeningTime(int seconds) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_totalListeningTimeKey, seconds);
+  }
+
+  Future<int> getTotalListeningTime() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_totalListeningTimeKey) ?? 0;
   }
 }

--- a/lib/statistics_repository.dart
+++ b/lib/statistics_repository.dart
@@ -1,0 +1,18 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class StatisticsRepository {
+  static const _installDateKey = 'install_date';
+
+  Future<void> saveInstallDate() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!prefs.containsKey(_installDateKey)) {
+      await prefs.setString(_installDateKey, DateTime.now().toIso8601String());
+    }
+  }
+
+  Future<DateTime?> getInstallDate() async {
+    final prefs = await SharedPreferences.getInstance();
+    final dateString = prefs.getString(_installDateKey);
+    return dateString != null ? DateTime.parse(dateString) : null;
+  }
+}

--- a/lib/statistics_repository.dart
+++ b/lib/statistics_repository.dart
@@ -5,6 +5,7 @@ class StatisticsRepository {
   static const _totalListeningTimeKey = 'total_listening_time';
   static const _longestSessionKey = 'longest_session';
   static const _shortestSessionKey = 'shortest_session';
+  static const _weekdayListeningKey = 'weekday_listening';
 
   Future<void> saveInstallDate() async {
     final prefs = await SharedPreferences.getInstance();
@@ -47,5 +48,23 @@ class StatisticsRepository {
   Future<int> getShortestSession() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(_shortestSessionKey) ?? 0;
+  }
+
+  Future<void> saveWeekdayListening(Map<int, int> weekdayData) async {
+    final prefs = await SharedPreferences.getInstance();
+    final stringData = weekdayData.map((key, value) => MapEntry(key.toString(), value.toString()));
+    // SharedPreferences doesn't support saving maps directly, so we convert it to a list of strings
+    final list = stringData.entries.map((e) => '${e.key}:${e.value}').toList();
+    await prefs.setStringList(_weekdayListeningKey, list);
+  }
+
+  Future<Map<int, int>> getWeekdayListening() async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_weekdayListeningKey);
+    if (list == null) return {};
+    return Map.fromEntries(list.map((e) {
+      final parts = e.split(':');
+      return MapEntry(int.parse(parts[0]), int.parse(parts[1]));
+    }));
   }
 }

--- a/lib/statistics_service.dart
+++ b/lib/statistics_service.dart
@@ -1,11 +1,47 @@
+import 'dart:async';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:flutter/foundation.dart';
 import 'statistics_repository.dart';
 
 class StatisticsService {
   final StatisticsRepository _repository;
+  final AudioHandler _audioHandler;
+  Timer? _timer;
+  int _totalListeningTime = 0;
 
-  StatisticsService(this._repository);
+  StatisticsService(this._repository, this._audioHandler);
 
   Future<void> init() async {
     await _repository.saveInstallDate();
+    _totalListeningTime = await _repository.getTotalListeningTime();
+
+    _audioHandler.playbackState.listen((playbackState) {
+      final isPlaying = playbackState.playing;
+      if (isPlaying) {
+        _startTimer();
+      } else {
+        _stopTimer();
+      }
+    });
+  }
+
+  void _startTimer() {
+    _timer ??= Timer.periodic(const Duration(seconds: 1), (_) {
+      _totalListeningTime++;
+      if (_totalListeningTime % 10 == 0) {
+        _repository.saveTotalListeningTime(_totalListeningTime);
+      }
+    });
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void dispose() {
+    _stopTimer();
+    _repository.saveTotalListeningTime(_totalListeningTime);
   }
 }

--- a/lib/statistics_service.dart
+++ b/lib/statistics_service.dart
@@ -26,6 +26,14 @@ class StatisticsService {
     });
   }
 
+  Future<DateTime?> getInstallDate() {
+    return _repository.getInstallDate();
+  }
+
+  Future<int> getTotalListeningTime() {
+    return _repository.getTotalListeningTime();
+  }
+
   void _startTimer() {
     _timer ??= Timer.periodic(const Duration(seconds: 1), (_) {
       _totalListeningTime++;

--- a/lib/statistics_service.dart
+++ b/lib/statistics_service.dart
@@ -1,0 +1,11 @@
+import 'statistics_repository.dart';
+
+class StatisticsService {
+  final StatisticsRepository _repository;
+
+  StatisticsService(this._repository);
+
+  Future<void> init() async {
+    await _repository.saveInstallDate();
+  }
+}

--- a/lib/statistics_service.dart
+++ b/lib/statistics_service.dart
@@ -20,12 +20,12 @@ class StatisticsService {
     _totalListeningTime = await _repository.getTotalListeningTime();
     _weekdayListening = await _repository.getWeekdayListening();
 
-    _audioHandler.playbackState.listen((playbackState) {
+    _audioHandler.playbackState.listen((playbackState) async {
       final isPlaying = playbackState.playing;
       if (isPlaying) {
         _startTimers();
       } else {
-        _stopTimers();
+        await _stopTimers();
       }
     });
   }
@@ -80,12 +80,12 @@ class StatisticsService {
     });
   }
 
-  void _stopTimers() {
+  Future<void> _stopTimers() async {
     _totalTimeTimer?.cancel();
     _totalTimeTimer = null;
     _sessionTimer?.cancel();
     _sessionTimer = null;
-    _updateSessionStats();
+    await _updateSessionStats();
     _currentSessionTime = 0;
   }
 
@@ -95,7 +95,8 @@ class StatisticsService {
   }
 
   Future<void> _updateSessionStats() async {
-    if (_currentSessionTime == 0) return;
+    // Ignore sessions shorter than a minute
+    if (_currentSessionTime < 60) return;
 
     final longestSession = await _repository.getLongestSession();
     if (_currentSessionTime > longestSession) {
@@ -108,9 +109,9 @@ class StatisticsService {
     }
   }
 
-  void dispose() {
-    _stopTimers();
-    _repository.saveTotalListeningTime(_totalListeningTime);
-    _repository.saveWeekdayListening(_weekdayListening);
+  Future<void> dispose() async {
+    await _stopTimers();
+    await _repository.saveTotalListeningTime(_totalListeningTime);
+    await _repository.saveWeekdayListening(_weekdayListening);
   }
 }

--- a/lib/statistics_service.dart
+++ b/lib/statistics_service.dart
@@ -7,8 +7,10 @@ import 'statistics_repository.dart';
 class StatisticsService {
   final StatisticsRepository _repository;
   final AudioHandler _audioHandler;
-  Timer? _timer;
+  Timer? _totalTimeTimer;
+  Timer? _sessionTimer;
   int _totalListeningTime = 0;
+  int _currentSessionTime = 0;
 
   StatisticsService(this._repository, this._audioHandler);
 
@@ -19,9 +21,9 @@ class StatisticsService {
     _audioHandler.playbackState.listen((playbackState) {
       final isPlaying = playbackState.playing;
       if (isPlaying) {
-        _startTimer();
+        _startTimers();
       } else {
-        _stopTimer();
+        _stopTimers();
       }
     });
   }
@@ -34,22 +36,51 @@ class StatisticsService {
     return _repository.getTotalListeningTime();
   }
 
-  void _startTimer() {
-    _timer ??= Timer.periodic(const Duration(seconds: 1), (_) {
+  Future<int> getLongestSession() {
+    return _repository.getLongestSession();
+  }
+
+  Future<int> getShortestSession() {
+    return _repository.getShortestSession();
+  }
+
+  void _startTimers() {
+    _totalTimeTimer ??= Timer.periodic(const Duration(seconds: 1), (_) {
       _totalListeningTime++;
       if (_totalListeningTime % 10 == 0) {
         _repository.saveTotalListeningTime(_totalListeningTime);
       }
     });
+    _sessionTimer ??= Timer.periodic(const Duration(seconds: 1), (_) {
+      _currentSessionTime++;
+    });
   }
 
-  void _stopTimer() {
-    _timer?.cancel();
-    _timer = null;
+  void _stopTimers() {
+    _totalTimeTimer?.cancel();
+    _totalTimeTimer = null;
+    _sessionTimer?.cancel();
+    _sessionTimer = null;
+    _updateSessionStats();
+    _currentSessionTime = 0;
+  }
+
+  Future<void> _updateSessionStats() async {
+    if (_currentSessionTime == 0) return;
+
+    final longestSession = await _repository.getLongestSession();
+    if (_currentSessionTime > longestSession) {
+      await _repository.saveLongestSession(_currentSessionTime);
+    }
+
+    final shortestSession = await _repository.getShortestSession();
+    if (_currentSessionTime < shortestSession || shortestSession == 0) {
+      await _repository.saveShortestSession(_currentSessionTime);
+    }
   }
 
   void dispose() {
-    _stopTimer();
+    _stopTimers();
     _repository.saveTotalListeningTime(_totalListeningTime);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   html: ^0.15.0
   flutter_local_notifications: ^19.5.0
   scrollable_positioned_list: ^0.3.8
+  shared_preferences: ^2.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request builds upon the initial statistics feature, introducing significant improvements to its reliability, user experience, and code quality. It addresses several bugs and adds final touches to the presentation layer.
Key Enhancements & Fixes:
•Asynchronous Bug Fix:
◦Corrected a critical race condition where session statistics were reset before they could be saved. The StatisticsService now correctly awaits the save operation, ensuring data integrity.

•Improved Data Filtering:
◦Listening sessions shorter than 60 seconds are now ignored, preventing insignificant data from cluttering the statistics.
◦The UI has been updated to conditionally render statistics. Sections for which no data is available (e.g., "shortest session" before any sessions are recorded) are now hidden, creating a cleaner user experience.
◦The page includes a loading indicator while fetching data and conditionally renders statistics, hiding entries for which no data is available yet.

•Comprehensive Statistics Tracking:
◦Session Tracking: Records the longest and shortest listening sessions. Sessions shorter than one minute are ignored.
◦Most Listened Day: Identifies and displays the day of the week with the highest listening time.


Code Quality & UX:
▪The implementation follows null-safety principles.
▪Durations and dates are formatted for readability, including correct Polish pluralization for time units ("minuta", "godzina").
▪An async bug in session saving has been identified and fixed.