### PR TITLE
Feat/contact page

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,5 +63,15 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Allow opening phone dialer -->
+        <intent>
+            <action android:name="android.intent.action.DIAL" />
+            <data android:scheme="tel" />
+        </intent>
+        <!-- Allow opening email client -->
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="mailto" />
+        </intent>
     </queries>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -73,5 +73,14 @@
             <action android:name="android.intent.action.SENDTO" />
             <data android:scheme="mailto" />
         </intent>
+        <!-- Allow opening web pages -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http" />
+        </intent>
     </queries>
 </manifest>

--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class ContactPage extends StatelessWidget {
+  const ContactPage({super.key});
+
+  Future<void> _launchUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    } else {
+      // TODO: Handle error
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Kontakt'),
+        backgroundColor: Colors.teal[900],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16.0),
+        children: [
+          _ContactInfoTile(
+            icon: Icons.phone,
+            label: 'Telefon antenowy',
+            value: '(+48 42) 63 13 888',
+            onTap: () => _launchUrl('tel:+48426313888'),
+          ),
+          const SizedBox(height: 16),
+          _ContactInfoTile(
+            icon: Icons.email,
+            label: 'E-mail',
+            value: 'radio@zak.lodz.pl',
+            onTap: () => _launchUrl('mailto:radio@zak.lodz.pl'),
+          ),
+          const Divider(height: 48),
+          Padding(
+            padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
+            child: Text(
+              'Telefony redakcyjne',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleLarge
+                  ?.copyWith(color: Colors.tealAccent),
+            ),
+          ),
+          _ContactInfoTile(
+            icon: Icons.phone_in_talk,
+            label: 'Redakcja',
+            value: '(+48 42) 63 12 844',
+            onTap: () => _launchUrl('tel:+48426312844'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContactInfoTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final VoidCallback onTap;
+
+  const _ContactInfoTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon, color: Colors.tealAccent, size: 32),
+      title: Text(label),
+      subtitle: Text(
+        value,
+        style: Theme.of(context)
+            .textTheme
+            .titleMedium
+            ?.copyWith(color: Colors.white),
+      ),
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(vertical: 8.0),
+    );
+  }
+}

--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -28,6 +28,11 @@ class ContactPage extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.all(16.0),
         children: [
+          const Text(
+            'Masz newsa, pytanie lub chcesz się po prostu z nami skontaktować? Użyj jednej z poniższych metod. Czekamy na Twoją wiadomość!',
+            style: TextStyle(fontSize: 16),
+          ),
+          const SizedBox(height: 32),
           _ContactInfoTile(
             icon: Icons.phone_in_talk_rounded,
             label: 'Telefon antenowy',

--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -24,7 +24,6 @@ class ContactPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Kontakt'),
-        backgroundColor: Colors.teal[900],
       ),
       body: ListView(
         padding: const EdgeInsets.all(16.0),

--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -41,6 +41,12 @@ class ContactPage extends StatelessWidget {
             value: 'radio@zak.lodz.pl',
             onTap: () => _launchUrl(context, 'mailto:radio@zak.lodz.pl'),
           ),
+          const SizedBox(height: 16),
+          _ContactInfoTile(
+            icon: Icons.message,
+            label: 'Napisz przez Messenger',
+            onTap: () => _launchUrl(context, 'http://m.me/studentradiozak'),
+          ),
           const Divider(height: 48),
           Padding(
             padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
@@ -67,13 +73,13 @@ class ContactPage extends StatelessWidget {
 class _ContactInfoTile extends StatelessWidget {
   final IconData icon;
   final String label;
-  final String value;
+  final String? value;
   final VoidCallback onTap;
 
   const _ContactInfoTile({
     required this.icon,
     required this.label,
-    required this.value,
+    this.value,
     required this.onTap,
   });
 
@@ -81,14 +87,16 @@ class _ContactInfoTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       leading: Icon(icon, color: Colors.tealAccent, size: 32),
-      title: Text(label),
-      subtitle: Text(
-        value,
-        style: Theme.of(context)
-            .textTheme
-            .titleMedium
-            ?.copyWith(color: Colors.white),
-      ),
+      title: Text(label, style: Theme.of(context).textTheme.titleLarge),
+      subtitle: value != null
+          ? Text(
+              value!,
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(color: Colors.white70),
+            )
+          : null,
       onTap: onTap,
       contentPadding: const EdgeInsets.symmetric(vertical: 8.0),
     );

--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -4,12 +4,18 @@ import 'package:url_launcher/url_launcher.dart';
 class ContactPage extends StatelessWidget {
   const ContactPage({super.key});
 
-  Future<void> _launchUrl(String url) async {
+  Future<void> _launchUrl(BuildContext context, String url) async {
     final uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri);
     } else {
-      // TODO: Handle error
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Nie można otworzyć linku.'),
+          ),
+        );
+      }
     }
   }
 
@@ -27,14 +33,14 @@ class ContactPage extends StatelessWidget {
             icon: Icons.phone,
             label: 'Telefon antenowy',
             value: '(+48 42) 63 13 888',
-            onTap: () => _launchUrl('tel:+48426313888'),
+            onTap: () => _launchUrl(context, 'tel:+48426313888'),
           ),
           const SizedBox(height: 16),
           _ContactInfoTile(
             icon: Icons.email,
             label: 'E-mail',
             value: 'radio@zak.lodz.pl',
-            onTap: () => _launchUrl('mailto:radio@zak.lodz.pl'),
+            onTap: () => _launchUrl(context, 'mailto:radio@zak.lodz.pl'),
           ),
           const Divider(height: 48),
           Padding(
@@ -51,7 +57,7 @@ class ContactPage extends StatelessWidget {
             icon: Icons.phone_in_talk,
             label: 'Redakcja',
             value: '(+48 42) 63 12 844',
-            onTap: () => _launchUrl('tel:+48426312844'),
+            onTap: () => _launchUrl(context, 'tel:+48426312844'),
           ),
         ],
       ),

--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -29,12 +29,19 @@ class ContactPage extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         children: [
           _ContactInfoTile(
+            icon: Icons.phone_in_talk,
+            label: 'Telefony redakcyjne',
+            value: '(+48 42) 63 12 844',
+            onTap: () => _launchUrl(context, 'tel:+48426312844'),
+          ),
+          const SizedBox(height: 16),
+          _ContactInfoTile(
             icon: Icons.phone,
             label: 'Telefon antenowy',
             value: '(+48 42) 63 13 888',
             onTap: () => _launchUrl(context, 'tel:+48426313888'),
           ),
-          const SizedBox(height: 16),
+          const Divider(height: 32),
           _ContactInfoTile(
             icon: Icons.email,
             label: 'E-mail',
@@ -46,23 +53,6 @@ class ContactPage extends StatelessWidget {
             icon: Icons.message,
             label: 'Napisz przez Messenger',
             onTap: () => _launchUrl(context, 'http://m.me/studentradiozak'),
-          ),
-          const Divider(height: 48),
-          Padding(
-            padding: const EdgeInsets.only(left: 16.0, bottom: 8.0),
-            child: Text(
-              'Telefony redakcyjne',
-              style: Theme.of(context)
-                  .textTheme
-                  .titleLarge
-                  ?.copyWith(color: Colors.tealAccent),
-            ),
-          ),
-          _ContactInfoTile(
-            icon: Icons.phone_in_talk,
-            label: 'Redakcja',
-            value: '(+48 42) 63 12 844',
-            onTap: () => _launchUrl(context, 'tel:+48426312844'),
           ),
         ],
       ),

--- a/lib/contact_page.dart
+++ b/lib/contact_page.dart
@@ -29,17 +29,18 @@ class ContactPage extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         children: [
           _ContactInfoTile(
-            icon: Icons.phone_in_talk,
-            label: 'Telefony redakcyjne',
-            value: '(+48 42) 63 12 844',
-            onTap: () => _launchUrl(context, 'tel:+48426312844'),
+            icon: Icons.phone_in_talk_rounded,
+            label: 'Telefon antenowy',
+            value: '(+48 42) 63 13 888',
+            onTap: () => _launchUrl(context, 'tel:+48426313888'),
+            isLive: true,
           ),
           const SizedBox(height: 16),
           _ContactInfoTile(
             icon: Icons.phone,
-            label: 'Telefon antenowy',
-            value: '(+48 42) 63 13 888',
-            onTap: () => _launchUrl(context, 'tel:+48426313888'),
+            label: 'Telefony redakcyjne',
+            value: '(+48 42) 63 12 844',
+            onTap: () => _launchUrl(context, 'tel:+48426312844'),
           ),
           const Divider(height: 32),
           _ContactInfoTile(
@@ -65,19 +66,41 @@ class _ContactInfoTile extends StatelessWidget {
   final String label;
   final String? value;
   final VoidCallback onTap;
+  final bool isLive;
 
   const _ContactInfoTile({
     required this.icon,
     required this.label,
     this.value,
     required this.onTap,
+    this.isLive = false,
   });
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
       leading: Icon(icon, color: Colors.tealAccent, size: 32),
-      title: Text(label, style: Theme.of(context).textTheme.titleLarge),
+      title: Row(
+        children: [
+          Text(label, style: Theme.of(context).textTheme.titleLarge),
+          if (isLive)
+            Padding(
+              padding: const EdgeInsets.only(left: 8.0),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.red[700],
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: const Text(
+                  'LIVE',
+                  style: TextStyle(
+                      color: Colors.white, fontWeight: FontWeight.bold, fontSize: 10),
+                ),
+              ),
+            ),
+        ],
+      ),
       subtitle: value != null
           ? Text(
               value!,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:logging/logging.dart';
+import 'package:zakstreamer/contact_page.dart';
 import 'package:zakstreamer/widgets/play_button.dart';
 import 'package:zakstreamer/widgets/now_playing_widget.dart';
 import 'page_manager.dart';
@@ -110,7 +111,7 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       body: Center(
         child: Padding(
-          padding: EdgeInsets.symmetric(vertical: 36, horizontal: 12),
+          padding: const EdgeInsets.symmetric(vertical: 36, horizontal: 12),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             crossAxisAlignment: CrossAxisAlignment.center,
@@ -128,6 +129,20 @@ class HomePage extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => const SchedulePage(),
+                    ),
+                  );
+                },
+              ),
+              TextButton(
+                child: const Text(
+                  'KONTAKT',
+                  style: TextStyle(color: Colors.tealAccent),
+                ),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const ContactPage(),
                     ),
                   );
                 },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   html: ^0.15.0
   flutter_local_notifications: ^19.5.0
   scrollable_positioned_list: ^0.3.8
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a new, fully functional "Contact" page, providing users with multiple ways to get in touch with the station. The feature is designed to be user-friendly, with interactive elements and clear visual cues.
Key Features & Implementation Details
•New Contact Page:
◦A dedicated contact page has been created, featuring a layout consistent with the app's branding and color scheme.
◦An introductory text explains the purpose of the page to the user.

•Interactive Contact Options:
◦The page includes clickable options for:

▪On-air phone: Opens the phone dialer with the number pre-filled. This option is visually marked with a "LIVE" badge for clarity.
▪Office phone: Opens the dialer with the office number.
▪Email: Launches the default email client with the station's address pre-filled.
▪Messenger: Opens a conversation with the station's Facebook page.

•Android Integration & Bug Fixes:
◦The url_launcher library is used to handle all external actions.
◦The AndroidManifest.xml file has been updated with the necessary <queries> to ensure these links work correctly on modern Android versions (Android 11+), fixing package visibility issues.
◦Includes error handling: if an action cannot be completed (e.g., no email app is installed), a SnackBar is shown to the user.

•Code & UI Refinements:
◦The layout was reordered to prioritize phone numbers.
◦The code for contact list items was refactored into a reusable _ContactInfoTile widget, which supports optional subtitles and the "LIVE" badge.